### PR TITLE
Revert "Zugriff auf Anmeldedaten per HTTP Basic Auth"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .env
-public/.htpasswd
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -4,12 +4,7 @@ Options -Indexes
 ServerSignature Off
 Header unset X-Powered-By
 
-<FilesMatch ".*\.csv$">
-  AuthType Basic
-  AuthName "NdH-Registrierung"
-  AuthUserFile /.htpasswd
-  Require valid-user
-</FilesMatch>
+RedirectMatch 404 ".*\.csv$"
 
 ErrorDocument 403 "403 - Forbidden"
 ErrorDocument 404 "404 - Not Found"
@@ -23,7 +18,7 @@ RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^ /registration.php [QSA,L]
+RewriteRule ^ registration.php [QSA,L]
 
 RewriteCond %{REQUEST_URI} "!(^|/)\.well-known/([^./]+./?)+$" [NC]
 RewriteCond %{SCRIPT_FILENAME} -d [OR]


### PR DESCRIPTION
Reverts nacht-des-heiligtums/registrierung.nachtdesheiligtums.de#1

Der Download per HTTP Auth funktioniert nicht.

Ich habe erstmal die FTP-Daten an Adilia durchgegeben, wenn das klappt, können wir diese Änderungen wieder rückgängig machen.

Ansonsten müssen wir nochmal schauen ob wir HTTP Auth hinbekommen oder eine andere Lösung finden (Dropbox Sync, Authentifizierung per PHP).